### PR TITLE
Enable doxygen check.

### DIFF
--- a/delphyne_demos/CMakeLists.txt
+++ b/delphyne_demos/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BUILD_DOCS)
   ament_doxygen_generate(doxygen_maliput_malidrive
     CONFIG_OVERLAY doc/Doxyfile.overlay.in
     DEPENDENCIES delphyne delphyne_gui
+    TEST_ON_WARNS
   )
 endif()
 


### PR DESCRIPTION
Related to ToyotaResearchInstitute/maliput_infrastructure#227