### PR TITLE
Allows layout selection for the demos.

### DIFF
--- a/delphyne_demos/demos/city.py
+++ b/delphyne_demos/demos/city.py
@@ -137,7 +137,7 @@ def main():
 
     tree_time_step = 0.02
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/crash.py
+++ b/delphyne_demos/demos/crash.py
@@ -128,7 +128,7 @@ def main():
 
     tree_time_step = 0.02
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/dragway.py
+++ b/delphyne_demos/demos/dragway.py
@@ -99,7 +99,7 @@ def main():
 
     tree_time_step = 0.02
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/gazoo.py
+++ b/delphyne_demos/demos/gazoo.py
@@ -154,7 +154,7 @@ def main():
 
     tree_time_step = 0.03
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/helpers.py
+++ b/delphyne_demos/demos/helpers.py
@@ -66,5 +66,9 @@ def create_argument_parser(title, content, default_duration=-1.0):
                                              'visualizer (default: False)'))
     parser.add_argument('-y', '--layout', default="layout_with_teleop.config",
                         action='store', type=str,
-                        help='Custom layout config file (default: layout_with_teleop.config)')
+                        help='Custom layout config file path.'
+                             'If the path is relative it will look for it '
+                             'first at env `DELPHYNE_GUI_RESOURCE_ROOT/layouts` '
+                             'location and then at the execution location. '
+                             '(default: layout_with_teleop.config)')
     return parser

--- a/delphyne_demos/demos/keyop.py
+++ b/delphyne_demos/demos/keyop.py
@@ -161,7 +161,7 @@ def main():
 
     tree_time_step = 0.02
     with launch_interactive_simulation(
-            simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+            simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/mali.py
+++ b/delphyne_demos/demos/mali.py
@@ -316,7 +316,7 @@ def main():
 
     tree_time_step = 0.03
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/mobil_perf.py
+++ b/delphyne_demos/demos/mobil_perf.py
@@ -222,7 +222,7 @@ def main():
 
     tree_time_step = 0.02
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/realtime.py
+++ b/delphyne_demos/demos/realtime.py
@@ -112,7 +112,7 @@ def main():
 
     tree_time_step = 0.02
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/roads.py
+++ b/delphyne_demos/demos/roads.py
@@ -35,7 +35,14 @@ being the following road network types are supported:
 dragway, onramp, and multilane.
 
 This demo uses the subcommand style, where each road
-type can handle different parameters. To get help on each
+type can handle different parameters.
+
+The optional arguments that are common to all the roads
+should be located before the road type.
+
+$ {0} --help
+
+To get help on each
 road type's parameters, run for example:
 
 $ {0} multilane --help
@@ -141,7 +148,7 @@ def main():
 
     tree_time_step = 0.02
     with launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/scriptlets.py
+++ b/delphyne_demos/demos/scriptlets.py
@@ -189,7 +189,7 @@ def main():
 
     tree_time_step = 0.02
     with delphyne_gui.utilities.launch_interactive_simulation(
-        simulation_tree.runner, bare=args.bare, ign_visualizer="visualizer"
+        simulation_tree.runner, layout=args.layout, bare=args.bare, ign_visualizer="visualizer"
     ) as launcher:
         if args.duration < 0:
             # run indefinitely

--- a/delphyne_demos/demos/trip_integration.py
+++ b/delphyne_demos/demos/trip_integration.py
@@ -180,7 +180,7 @@ def main():
           "************************************************************\n")
 
     with launch_interactive_simulation(
-            simulation_tree.runner, bare=args.bare
+            simulation_tree.runner, layout=args.layout, bare=args.bare
     ) as launcher:
         if args.duration < 0:
             # run indefinitely


### PR DESCRIPTION
Pairs with https://github.com/ToyotaResearchInstitute/delphyne_gui/pull/459
Related to https://github.com/ToyotaResearchInstitute/delphyne/issues/806

Allows demos to use different layouts.


Example using `delphyne_gazoo`:
```sh
delphyne_gazoo
```
1 - Generate a layout from the gui visualizer: 
   - a: Modify the gui as you pleased

![image](https://user-images.githubusercontent.com/53065142/134370813-7ff014ed-d39a-4317-a739-810638447ef5.png)

   - b: Save the configuration: 

![image](https://user-images.githubusercontent.com/53065142/134369913-4b21148a-ac2f-4c51-b4f9-0e39adc794ff.png)
In this example I removed some widgets that are added by default and added the `screenshot` widget
Then I hit `Save configuration as` and saved this as "screenshot.config"

2 - Execute the `delphyne_gazoo` demo with a different layout
```
delphyne_gazoo --layout=/home/franco/screenshot.config
```

![image](https://user-images.githubusercontent.com/53065142/134370698-c314ba19-fe72-4080-8b54-c98e9422f783.png)


