### PR TITLE
Updates CI after change in delphyne's dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,14 @@ jobs:
         colcon build --packages-up-to ${PACKAGE_NAME} \
           --event-handlers=console_direct+ \
           --cmake-args -DBUILD_TESTING=OFF
+    - name: colcon build maliput backends
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+      run: |
+        . /opt/ros/${ROS_DISTRO}/setup.bash;
+        colcon build --packages-up-to maliput_dragway maliput_multilane maliput_malidrive \
+          --event-handlers=console_direct+ \
+          --cmake-args -DBUILD_TESTING=OFF
     - name: colcon build tests
       shell: bash
       working-directory: ${{ env.ROS_WS }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -128,6 +128,15 @@ jobs:
           --event-handlers=console_direct+ \
           --cmake-args ${COMPILER_FLAG} \
             -DBUILD_TESTING=OFF;
+    - name: colcon build maliput backends
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+      run: |
+        . /opt/ros/${ROS_DISTRO}/setup.bash;
+        colcon build --packages-up-to maliput_dragway maliput_multilane maliput_malidrive \
+          --event-handlers=console_direct+ \
+          --cmake-args ${COMPILER_FLAG} \
+            -DBUILD_TESTING=OFF
     - name: colcon build tests
       shell: bash
       working-directory: ${{ env.ROS_WS }}

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -43,24 +43,6 @@ jobs:
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/maliput_malidrive
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_malidrive
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_dragway
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_dragway
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_multilane
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_multilane
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
         repository: ToyotaResearchInstitute/delphyne
         fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/delphyne
@@ -70,12 +52,6 @@ jobs:
         repository: ToyotaResearchInstitute/delphyne_gui
         fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/delphyne_gui
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput_drake
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput_drake
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Pairs with ToyotaResearchInstitute/delphyne#816
Related to ToyotaResearchInstitute/delphyne#804

Updates CI job after delphyne is not depending on maliput backends