### PR TITLE
Adds elevated_arc_lane.osm to the mali_osm demos.

### DIFF
--- a/demos/mali_osm.py
+++ b/demos/mali_osm.py
@@ -81,6 +81,15 @@ KNOWN_ROADS = {
         'moving_forward': True,
         'linear_tolerance': 1e-3,
     },
+    'ElevatedArcLane': {
+        'description': 'Arc-shaped road with an increasing elevation',
+        'file_path': 'elevated_arc_lane.osm',
+        'origin': '{0., 0.}',
+        'lane_id': '1191',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 1e-3,
+    },
 }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,10 @@ if (NOT ${SANITIZERS})
     COMMAND delphyne_mali_osm -n ArcLaneDense -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_mali_osm_elevated_arc_lane_dense
+    COMMAND delphyne_mali_osm -n ElevatedArcLane -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_mali_line_single_lane
     COMMAND delphyne_mali -n LineSingleLane -b -d 2
   )


### PR DESCRIPTION
# 🎉 New feature

Relies on https://github.com/maliput/maliput_osm/pull/23

## Summary
Adds demo using `elevated_arc_lane.osm` map

https://user-images.githubusercontent.com/53065142/195358186-6f196b7a-720a-4e85-9b94-eec3e43badcf.mp4

https://user-images.githubusercontent.com/53065142/195358209-d20032f5-3e7a-4741-8a69-b7982523577d.mp4


## Test it
```sh
delphyne_mali_osm -n ElevatedArcLane -p
```


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
