### PR TITLE
Adds maliput_osm demo with CShapeSuperelevatedRoad map.

### DIFF
--- a/demos/mali_osm.py
+++ b/demos/mali_osm.py
@@ -90,6 +90,15 @@ KNOWN_ROADS = {
         'moving_forward': True,
         'linear_tolerance': 1e-3,
     },
+    'CShapeSuperelevatedRoad': {
+        'description': 'C-shaped road with an variation in superelevation',
+        'file_path': 'c_shape_superelevated_road.osm',
+        'origin': '{0., 0.}',
+        'lane_id': '1498',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 1e-3,
+    },
 }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,10 @@ if (NOT ${SANITIZERS})
     COMMAND delphyne_mali_osm -n ElevatedArcLane -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_mali_osm_c_shape_superelevated_road
+    COMMAND delphyne_mali_osm -n CShapeSuperelevatedRoad -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_mali_line_single_lane
     COMMAND delphyne_mali -n LineSingleLane -b -d 2
   )


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_osm/pull/29
Related to https://github.com/maliput/maliput_sparse/pull/38


## Summary

https://user-images.githubusercontent.com/53065142/197206985-f84a9511-11fc-4be8-b884-a4746c52c520.mp4

## Test it

```
delphyne_mali_osm -n CShapeSuperelevatedRoad
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
