### PR TITLE
Adds demo for the L Shape road.

### DIFF
--- a/demos/mali_osm.py
+++ b/demos/mali_osm.py
@@ -99,6 +99,15 @@ KNOWN_ROADS = {
         'moving_forward': True,
         'linear_tolerance': 1e-3,
     },
+    'LShapeRoad': {
+        'description': 'L-shaped road.',
+        'file_path': 'l_shape_road.osm',
+        'origin': '{0., 0.}',
+        'lane_id': '1206',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 1e-3,
+    },
 }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,10 @@ if (NOT ${SANITIZERS})
     COMMAND delphyne_mali_osm -n CShapeSuperelevatedRoad -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_mali_osm_l_shape_road
+    COMMAND delphyne_mali_osm -n LShapeRoad -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_mali_line_single_lane
     COMMAND delphyne_mali -n LineSingleLane -b -d 2
   )


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary
Adds demo for the l shape road. This demos shows that connections between lanes are supported. (Correct Branchpoint population.)

Relies on https://github.com/maliput/maliput_osm/pull/33

https://user-images.githubusercontent.com/53065142/199282218-afa4ea4c-e110-4282-8bb4-92b6694933d4.mp4



## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

