### PR TITLE
Adds TShapeRoad map for mali_osm demo.

### DIFF
--- a/demos/mali_osm.py
+++ b/demos/mali_osm.py
@@ -108,6 +108,15 @@ KNOWN_ROADS = {
         'moving_forward': True,
         'linear_tolerance': 1e-3,
     },
+    'TShapeRoad': {
+        'description': 'T-shaped road.',
+        'file_path': 't_shape_road.osm',
+        'origin': '{0., 0.}',
+        'lane_id': '1830',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 1e-3,
+    },
 }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,10 @@ if (NOT ${SANITIZERS})
     COMMAND delphyne_mali_osm -n LShapeRoad -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_mali_osm_t_shape_road
+    COMMAND delphyne_mali_osm -n TShapeRoad -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_mali_line_single_lane
     COMMAND delphyne_mali -n LineSingleLane -b -d 2
   )


### PR DESCRIPTION
# 🎉 New feature

Relies on https://github.com/maliput/maliput_osm/pull/43

## Summary

Adds TShapeRoad demo.

https://user-images.githubusercontent.com/53065142/200662337-7f8a675a-1e79-416f-ad6a-12c599ec96ed.mp4



## Test it
```
delphyne_mali_osm -n TShapeRoad -p
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
