### PR TITLE
Adds circuit demo.

### DIFF
--- a/demos/mali_osm.py
+++ b/demos/mali_osm.py
@@ -126,6 +126,15 @@ KNOWN_ROADS = {
         'moving_forward': True,
         'linear_tolerance': 1e-3,
     },
+    'Circuit': {
+        'description': 'A circuit map.',
+        'file_path': 'circuit.osm',
+        'origin': '{0., 0.}',
+        'lane_id': '2158',
+        'lane_position': 0.,
+        'moving_forward': True,
+        'linear_tolerance': 1e-3,
+    },
 }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,10 @@ if (NOT ${SANITIZERS})
     NAME smoke_test_delphyne_mali_osm_t_shape_road
     COMMAND delphyne_mali_osm -n TShapeRoad -b -d 2
   )
+  add_test(
+    NAME smoke_test_delphyne_mali_osm_circuit
+    COMMAND delphyne_mali_osm -n Circuit -b -d 2
+  )
 
   ## delphyne_mali
   add_test(


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_osm/pull/44

## Summary
Adds demo on circuit.osm map.


https://user-images.githubusercontent.com/53065142/201667900-cdc473d4-34f0-45bc-896c-d6591de5d348.mp4



## Test it
```
delphyne_mali_osm -n Circuit -p
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

