### PR TITLE
Supports maliput_osm as backend for delphyne_gazoo demo.

### DIFF
--- a/demos/gazoo.py
+++ b/demos/gazoo.py
@@ -40,7 +40,7 @@ The gazoo demo.
 
 import os.path
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 
 import delphyne.behaviours
 import delphyne.trees
@@ -55,7 +55,7 @@ from . import helpers
 ##############################################################################
 
 
-class MaliputBackend(StrEnum):
+class MaliputBackend(Enum):
     MALIPUT_MULTILANE = "maliput_multilane"
     MALIPUT_OSM = "maliput_osm"
 
@@ -91,19 +91,17 @@ class ScenarioSubtreeConfig:
 
 def get_scenario_subtree_config(backend):
     """Obtain the circuit filepath based on the selected backend."""
-    if backend == MaliputBackend.MALIPUT_MULTILANE:
+    if MaliputBackend(backend) == MaliputBackend.MALIPUT_MULTILANE:
         config = ScenarioSubtreeConfig(name="circuit_multilane",
                                        circuit_filepath=get_delphyne_gui_circuit(),
                                        lanes=["l:s1_0", "l:s1_1", "l:s1_2"])
-    elif(backend == MaliputBackend.MALIPUT_OSM):
+    elif(MaliputBackend(backend) == MaliputBackend.MALIPUT_OSM):
         config = ScenarioSubtreeConfig(name="circuit_osm",
                                        circuit_filepath=get_maliput_osm_circuit(),
                                        lanes=["1825", "1405", "1352"],
                                        origin="{0., 0.}")
-
-    if not os.path.isfile(config.circuit_filepath):
-        print("Required map 'circuit' not found for the backend: {}"
-              .format(backend))
+    else:
+        print("Backend {} not supported".format(backend))
         quit()
     return config
 
@@ -199,19 +197,22 @@ def add_agents_to_scenario(scenario_subtree, mobil_cars_num, lanes):
 
 def create_gazoo_scenario_subtree(backend, mobil_cars_num):
     "Creates the Gazoo scenario subtree."
-
+    print("Creating Gazoo scenario subtree...")
     config = get_scenario_subtree_config(backend)
-
+    if not os.path.isfile(config.circuit_filepath):
+        print("Required map 'circuit' not found for the backend: {}"
+              .format(backend))
+        quit()
     features = delphyne.roads.ObjFeatures()
     features.draw_elevation_bounds = False
-    if(backend == MaliputBackend.MALIPUT_MULTILANE):
+    if(MaliputBackend(backend) == MaliputBackend.MALIPUT_MULTILANE):
         scenario_subtree = delphyne.behaviours.roads.Multilane(
             file_path=config.circuit_filepath,
             name=config.name,
             features=features,
 
         )
-    elif(backend == MaliputBackend.MALIPUT_OSM):
+    elif(MaliputBackend(backend) == MaliputBackend.MALIPUT_OSM):
         scenario_subtree = delphyne.behaviours.roads.MaliputOSM(
             file_path=config.circuit_filepath,
             name=config.name,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,6 +145,10 @@ if (NOT ${SANITIZERS})
     COMMAND delphyne_gazoo -b -d 2
   )
   add_test(
+    NAME smoke_test_delphyne_gazoo_osm
+    COMMAND delphyne_gazoo -m maliput_osm -b -d 2
+  )
+  add_test(
     NAME smoke_test_delphyne_city
     COMMAND delphyne_city -b -d 2
   )


### PR DESCRIPTION
# 🎉 New feature

Relies on https://github.com/maliput/delphyne/pull/858

## Summary
Supports using maliput_osm backend for the `delphyne_gazoo` demo.


https://user-images.githubusercontent.com/53065142/201933179-26f462e1-f2f2-4ce5-b8fa-d23773401130.mp4

## Test it
<!--Explain how reviewers can test this new feature manually.-->

```
delphyne_gazoo -m maliput_osm
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
